### PR TITLE
feat/#5: 전적 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
     // Swagger/OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+    // AWS SDK S3
+    implementation platform('software.amazon.awssdk:bom:2.20.0')
+    implementation 'software.amazon.awssdk:s3'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/lol/highlight/domain/match/controller/MatchHistoryController.java
+++ b/src/main/java/com/lol/highlight/domain/match/controller/MatchHistoryController.java
@@ -1,0 +1,62 @@
+package com.lol.highlight.domain.match.controller;
+
+import com.lol.highlight.domain.match.dto.MatchDetailResponse;
+import com.lol.highlight.domain.match.dto.MatchResponse;
+import com.lol.highlight.domain.match.service.MatchHistoryService;
+import com.lol.highlight.global.common.ApiResponse;
+import com.lol.highlight.global.config.SwaggerConfig.ApiErrorExamples;
+import com.lol.highlight.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Match History", description = "전적 조회 및 갱신 API")
+@RestController
+@RequestMapping("/api/matches")
+@RequiredArgsConstructor
+public class MatchHistoryController {
+
+    private final MatchHistoryService matchHistoryService;
+
+    @Operation(summary = "사용자 전적 목록 조회", description = "사용자의 전적 목록을 페이징하여 조회합니다. 마지막 활동 시간을 업데이트합니다.")
+    @GetMapping("/user/{userId}")
+    public ApiResponse<Page<MatchResponse>> getUserMatches(
+            @Parameter(description = "사용자 ID") @PathVariable Long userId,
+            Pageable pageable) {
+        Page<MatchResponse> matches = matchHistoryService.getUserMatches(userId, pageable);
+        return ApiResponse.success(matches);
+    }
+
+    @Operation(summary = "매치 상세 정보 조회", description = "S3에서 매치 상세 데이터를 가져와 반환합니다.")
+    @ApiErrorExamples({
+            ErrorCode.MATCH_NOT_FOUND,
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.AUTHENTICATION_REQUIRED
+    })
+    @GetMapping("/{matchId}/detail")
+    public ApiResponse<MatchDetailResponse> getMatchDetail(
+            @Parameter(description = "매치 ID") @PathVariable Long matchId) {
+        MatchDetailResponse detail = matchHistoryService.getMatchDetail(matchId);
+        return ApiResponse.success(detail);
+    }
+
+    @Operation(summary = "전적 갱신", description = "Riot API에서 최신 전적을 가져와 갱신합니다. 3분에 한번만 가능합니다. 소환사 정보도 함께 갱신됩니다.")
+    @ApiErrorExamples({
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.EXTERNAL_API_ERROR,
+            ErrorCode.AUTHENTICATION_REQUIRED
+    })
+    @PostMapping("/user/{userId}/refresh")
+    public ApiResponse<List<MatchResponse>> refreshMatches(
+            @Parameter(description = "사용자 ID") @PathVariable Long userId) {
+        List<MatchResponse> matches = matchHistoryService.refreshMatches(userId);
+        return ApiResponse.success(matches, "전적이 성공적으로 갱신되었습니다");
+    }
+}

--- a/src/main/java/com/lol/highlight/domain/match/dto/MatchDetailResponse.java
+++ b/src/main/java/com/lol/highlight/domain/match/dto/MatchDetailResponse.java
@@ -1,0 +1,48 @@
+package com.lol.highlight.domain.match.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MatchDetailResponse {
+
+    private String matchId;
+    private List<PlayerDetail> players;
+    private List<TeamDetail> teams;
+
+    @Getter
+    @Builder
+    public static class PlayerDetail {
+        private String playerName;
+        private String championName;
+        private Integer kills;
+        private Integer deaths;
+        private Integer assists;
+        private Integer totalDamageDealt;
+        private Integer visionScore;
+        private Integer cs;
+        private List<Integer> finalItems;
+        private Integer goldEarned;
+        private List<ItemBuild> itemBuild;
+        private List<Integer> skillBuild;
+    }
+
+    @Getter
+    @Builder
+    public static class ItemBuild {
+        private Integer itemId;
+        private Integer timestamp;
+    }
+
+    @Getter
+    @Builder
+    public static class TeamDetail {
+        private Integer teamId;
+        private Boolean win;
+        private Integer totalObjectives;
+        private Integer totalKills;
+    }
+}

--- a/src/main/java/com/lol/highlight/domain/match/entity/Match.java
+++ b/src/main/java/com/lol/highlight/domain/match/entity/Match.java
@@ -44,11 +44,13 @@ public class Match extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String timelineData;
 
+    private String detailDataUrl;
+
     @Builder
     public Match(User user, String matchId, String championName, Integer kills,
                 Integer deaths, Integer assists, Double kda, Boolean win,
                 Integer gameDuration, Long gameCreation, MatchStatus status,
-                String timelineData) {
+                String timelineData, String detailDataUrl) {
         this.user = user;
         this.matchId = matchId;
         this.championName = championName;
@@ -61,12 +63,13 @@ public class Match extends BaseEntity {
         this.gameCreation = gameCreation;
         this.status = status != null ? status : MatchStatus.PENDING;
         this.timelineData = timelineData;
+        this.detailDataUrl = detailDataUrl;
     }
 
     public void updateMatchData(String championName, Integer kills, Integer deaths,
                                Integer assists, Double kda, Boolean win,
                                Integer gameDuration, Long gameCreation,
-                               String timelineData) {
+                               String timelineData, String detailDataUrl) {
         this.championName = championName;
         this.kills = kills;
         this.deaths = deaths;
@@ -76,7 +79,12 @@ public class Match extends BaseEntity {
         this.gameDuration = gameDuration;
         this.gameCreation = gameCreation;
         this.timelineData = timelineData;
+        this.detailDataUrl = detailDataUrl;
         this.status = MatchStatus.COMPLETED;
+    }
+
+    public void updateDetailDataUrl(String detailDataUrl) {
+        this.detailDataUrl = detailDataUrl;
     }
 
     public void updateStatus(MatchStatus status) {

--- a/src/main/java/com/lol/highlight/domain/match/service/MatchHistoryService.java
+++ b/src/main/java/com/lol/highlight/domain/match/service/MatchHistoryService.java
@@ -1,0 +1,292 @@
+package com.lol.highlight.domain.match.service;
+
+import com.lol.highlight.domain.match.dto.MatchDetailResponse;
+import com.lol.highlight.domain.match.dto.MatchResponse;
+import com.lol.highlight.domain.match.entity.Match;
+import com.lol.highlight.domain.match.entity.MatchStatus;
+import com.lol.highlight.domain.match.repository.MatchRepository;
+import com.lol.highlight.domain.user.entity.User;
+import com.lol.highlight.domain.user.repository.UserRepository;
+import com.lol.highlight.global.external.riot.client.RiotApiClient;
+import com.lol.highlight.global.external.riot.dto.RiotLeagueDto;
+import com.lol.highlight.global.external.riot.dto.RiotMatchDto;
+import com.lol.highlight.global.external.riot.dto.RiotSummonerDto;
+import com.lol.highlight.global.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MatchHistoryService {
+
+    private final MatchRepository matchRepository;
+    private final UserRepository userRepository;
+    private final RiotApiClient riotApiClient;
+    private final S3Service s3Service;
+
+    private static final int DEFAULT_MATCH_COUNT = 20;
+
+    @Transactional(readOnly = true)
+    public Page<MatchResponse> getUserMatches(Long userId, Pageable pageable) {
+        User user = getUserById(userId);
+
+        user.updateLastActivityAt();
+        userRepository.save(user);
+
+        boolean needsRefresh = shouldRefreshMatches(user);
+
+        if (needsRefresh) {
+            log.info("Last activity is more than 30 minutes ago. Consider refreshing matches for user: {}", userId);
+        }
+
+        Page<Match> matches = matchRepository.findByUserId(userId, pageable);
+        return matches.map(MatchResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public MatchDetailResponse getMatchDetail(Long matchId) {
+        Match match = matchRepository.findById(matchId)
+                .orElseThrow(() -> new IllegalArgumentException("Match not found: " + matchId));
+
+        if (match.getDetailDataUrl() == null) {
+            throw new IllegalStateException("Match detail data URL is not available");
+        }
+
+        MatchDetailResponse detailData = s3Service.downloadMatchData(match.getDetailDataUrl());
+        return detailData;
+    }
+
+    @Transactional
+    public List<MatchResponse> refreshMatches(Long userId) {
+        User user = getUserById(userId);
+
+        if (!user.canRefreshMatches()) {
+            throw new IllegalStateException("Match refresh is only allowed once every 3 minutes");
+        }
+
+        log.info("Starting match refresh for user: {}", userId);
+
+        refreshSummonerInfo(user);
+
+        List<Match> matches = fetchAndSaveMatches(user);
+
+        user.updateLastMatchRefreshAt();
+        user.updateLastActivityAt();
+
+        updateUserStatistics(user, matches);
+
+        userRepository.save(user);
+
+        log.info("Successfully refreshed {} matches for user: {}", matches.size(), userId);
+
+        return matches.stream()
+                .map(MatchResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    private void refreshSummonerInfo(User user) {
+        try {
+            RiotSummonerDto accountDto = riotApiClient.getSummonerByRiotId(
+                    user.getSummonerName(),
+                    user.getTagLine()
+            );
+
+            RiotSummonerDto summonerDto = riotApiClient.getSummonerByPuuid(accountDto.getPuuid());
+
+            List<RiotLeagueDto> leagues = riotApiClient.getLeagueBySummonerId(summonerDto.getId());
+
+            RiotLeagueDto rankedSolo = leagues.stream()
+                    .filter(league -> "RANKED_SOLO_5x5".equals(league.getQueueType()))
+                    .findFirst()
+                    .orElse(null);
+
+            if (rankedSolo != null) {
+                user.updateSummonerInfo(
+                        summonerDto.getProfileIconId(),
+                        summonerDto.getSummonerLevel(),
+                        rankedSolo.getTier(),
+                        rankedSolo.getRank(),
+                        rankedSolo.getLeaguePoints(),
+                        rankedSolo.getWins(),
+                        rankedSolo.getLosses()
+                );
+            } else {
+                user.updateSummonerInfo(
+                        summonerDto.getProfileIconId(),
+                        summonerDto.getSummonerLevel(),
+                        null, null, null, null, null
+                );
+            }
+
+            log.info("Successfully refreshed summoner info for user: {}", user.getId());
+
+        } catch (Exception e) {
+            log.error("Failed to refresh summoner info for user: {}", user.getId(), e);
+            throw new RuntimeException("Failed to refresh summoner info", e);
+        }
+    }
+
+    private List<Match> fetchAndSaveMatches(User user) {
+        try {
+            RiotSummonerDto accountDto = riotApiClient.getSummonerByRiotId(
+                    user.getSummonerName(),
+                    user.getTagLine()
+            );
+
+            List<String> matchIds = riotApiClient.getMatchIdsByPuuid(
+                    accountDto.getPuuid(),
+                    DEFAULT_MATCH_COUNT
+            );
+
+            List<Match> savedMatches = new ArrayList<>();
+
+            for (String matchId : matchIds) {
+                if (matchRepository.existsByMatchId(matchId)) {
+                    log.debug("Match already exists, skipping: {}", matchId);
+                    continue;
+                }
+
+                RiotMatchDto riotMatch = riotApiClient.getMatchById(matchId);
+                Match match = convertAndSaveMatch(user, riotMatch, accountDto.getPuuid());
+                savedMatches.add(match);
+            }
+
+            return savedMatches;
+
+        } catch (Exception e) {
+            log.error("Failed to fetch and save matches for user: {}", user.getId(), e);
+            throw new RuntimeException("Failed to fetch and save matches", e);
+        }
+    }
+
+    private Match convertAndSaveMatch(User user, RiotMatchDto riotMatch, String puuid) {
+        RiotMatchDto.Participant playerData = riotMatch.getInfo().getParticipants().stream()
+                .filter(p -> puuid.equals(p.getPuuid()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Player not found in match"));
+
+        MatchDetailResponse detailResponse = convertToMatchDetail(riotMatch);
+
+        String detailDataUrl = s3Service.uploadMatchData(
+                riotMatch.getMetadata().getMatchId(),
+                detailResponse
+        );
+
+        Double kda = calculateKda(playerData.getKills(), playerData.getDeaths(), playerData.getAssists());
+
+        Match match = Match.builder()
+                .user(user)
+                .matchId(riotMatch.getMetadata().getMatchId())
+                .championName(playerData.getChampionName())
+                .kills(playerData.getKills())
+                .deaths(playerData.getDeaths())
+                .assists(playerData.getAssists())
+                .kda(kda)
+                .win(playerData.getWin())
+                .gameDuration(riotMatch.getInfo().getGameDuration().intValue())
+                .gameCreation(riotMatch.getInfo().getGameCreation())
+                .status(MatchStatus.COMPLETED)
+                .detailDataUrl(detailDataUrl)
+                .build();
+
+        return matchRepository.save(match);
+    }
+
+    private MatchDetailResponse convertToMatchDetail(RiotMatchDto riotMatch) {
+        List<MatchDetailResponse.PlayerDetail> players = riotMatch.getInfo().getParticipants().stream()
+                .map(p -> {
+                    List<Integer> finalItems = List.of(
+                            p.getItem0(), p.getItem1(), p.getItem2(),
+                            p.getItem3(), p.getItem4(), p.getItem5(), p.getItem6()
+                    );
+
+                    return MatchDetailResponse.PlayerDetail.builder()
+                            .playerName(p.getSummonerName())
+                            .championName(p.getChampionName())
+                            .kills(p.getKills())
+                            .deaths(p.getDeaths())
+                            .assists(p.getAssists())
+                            .totalDamageDealt(p.getTotalDamageDealtToChampions())
+                            .visionScore(p.getVisionScore())
+                            .cs(p.getTotalMinionsKilled() + p.getNeutralMinionsKilled())
+                            .finalItems(finalItems)
+                            .goldEarned(p.getGoldEarned())
+                            .itemBuild(new ArrayList<>())
+                            .skillBuild(new ArrayList<>())
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        List<MatchDetailResponse.TeamDetail> teams = riotMatch.getInfo().getTeams().stream()
+                .map(t -> {
+                    int totalObjectives = t.getObjectives().getBaron().getKills()
+                            + t.getObjectives().getDragon().getKills()
+                            + t.getObjectives().getTower().getKills()
+                            + t.getObjectives().getInhibitor().getKills()
+                            + t.getObjectives().getRiftHerald().getKills();
+
+                    int totalKills = riotMatch.getInfo().getParticipants().stream()
+                            .filter(p -> p.getTeamId().equals(t.getTeamId()))
+                            .mapToInt(RiotMatchDto.Participant::getKills)
+                            .sum();
+
+                    return MatchDetailResponse.TeamDetail.builder()
+                            .teamId(t.getTeamId())
+                            .win(t.getWin())
+                            .totalObjectives(totalObjectives)
+                            .totalKills(totalKills)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return MatchDetailResponse.builder()
+                .matchId(riotMatch.getMetadata().getMatchId())
+                .players(players)
+                .teams(teams)
+                .build();
+    }
+
+    private void updateUserStatistics(User user, List<Match> newMatches) {
+        List<Match> allMatches = matchRepository.findTop20ByUserIdOrderByGameCreationDesc(user.getId());
+
+        if (allMatches.isEmpty()) {
+            return;
+        }
+
+        double averageKda = allMatches.stream()
+                .mapToDouble(m -> m.getKda() != null ? m.getKda() : 0.0)
+                .average()
+                .orElse(0.0);
+
+        user.updateStatistics(averageKda, null, null);
+    }
+
+    private Double calculateKda(Integer kills, Integer deaths, Integer assists) {
+        if (deaths == null || deaths == 0) {
+            return (kills != null ? kills : 0) + (assists != null ? assists : 0) * 1.0;
+        }
+        return ((kills != null ? kills : 0) + (assists != null ? assists : 0)) / (double) deaths;
+    }
+
+    private boolean shouldRefreshMatches(User user) {
+        if (user.getLastActivityAt() == null) {
+            return true;
+        }
+        return LocalDateTime.now().isAfter(user.getLastActivityAt().plusMinutes(30));
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+    }
+}

--- a/src/main/java/com/lol/highlight/domain/user/entity/User.java
+++ b/src/main/java/com/lol/highlight/domain/user/entity/User.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "users")
 @Getter
@@ -28,6 +30,28 @@ public class User extends BaseEntity {
 
     private String tagLine;
 
+    private Integer profileIconId;
+
+    private Long summonerLevel;
+
+    private String tier;
+
+    private String rank;
+
+    private Integer leaguePoints;
+
+    private Integer wins;
+
+    private Integer losses;
+
+    private Double winRate;
+
+    private Double averageKda;
+
+    private Double averageVisionScore;
+
+    private Double averageCsPerMin;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AuthProvider provider;
@@ -37,6 +61,10 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserRole role;
+
+    private LocalDateTime lastActivityAt;
+
+    private LocalDateTime lastMatchRefreshAt;
 
     @Builder
     public User(String email, String name, String profileImage, String riotId,
@@ -62,5 +90,41 @@ public class User extends BaseEntity {
         this.riotId = riotId;
         this.summonerName = summonerName;
         this.tagLine = tagLine;
+    }
+
+    public void updateLastActivityAt() {
+        this.lastActivityAt = LocalDateTime.now();
+    }
+
+    public void updateLastMatchRefreshAt() {
+        this.lastMatchRefreshAt = LocalDateTime.now();
+    }
+
+    public boolean canRefreshMatches() {
+        if (lastMatchRefreshAt == null) {
+            return true;
+        }
+        return LocalDateTime.now().isAfter(lastMatchRefreshAt.plusMinutes(3));
+    }
+
+    public void updateSummonerInfo(Integer profileIconId, Long summonerLevel,
+                                   String tier, String rank, Integer leaguePoints,
+                                   Integer wins, Integer losses) {
+        this.profileIconId = profileIconId;
+        this.summonerLevel = summonerLevel;
+        this.tier = tier;
+        this.rank = rank;
+        this.leaguePoints = leaguePoints;
+        this.wins = wins;
+        this.losses = losses;
+        if (wins != null && losses != null && (wins + losses) > 0) {
+            this.winRate = (double) wins / (wins + losses) * 100;
+        }
+    }
+
+    public void updateStatistics(Double averageKda, Double averageVisionScore, Double averageCsPerMin) {
+        this.averageKda = averageKda;
+        this.averageVisionScore = averageVisionScore;
+        this.averageCsPerMin = averageCsPerMin;
     }
 }

--- a/src/main/java/com/lol/highlight/global/config/S3Config.java
+++ b/src/main/java/com/lol/highlight/global/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.lol.highlight.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.access-key}")
+    private String accessKey;
+
+    @Value("${aws.s3.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/lol/highlight/global/config/SwaggerConfig.java
+++ b/src/main/java/com/lol/highlight/global/config/SwaggerConfig.java
@@ -1,19 +1,46 @@
 package com.lol.highlight.global.config;
 
+import com.lol.highlight.global.exception.ErrorCode;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import lombok.Builder;
+import lombok.Getter;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 public class SwaggerConfig {
+
+    @Autowired
+    private ApplicationContext applicationContext;
 
     @Bean
     public OpenAPI openAPI() {
@@ -41,5 +68,122 @@ public class SwaggerConfig {
                         new Server().url("https://api.lolhighlight.com").description("Production Server")))
                 .addSecurityItem(securityRequirement)
                 .components(components);
+    }
+
+    @Bean
+    public OperationCustomizer operationCustomizer() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            String actualPath = extractActualPath(handlerMethod);
+
+            ApiErrorExamples apiErrorExamples = handlerMethod.getMethodAnnotation(ApiErrorExamples.class);
+            if (apiErrorExamples != null) {
+                generateErrorCodeResponseExample(operation, apiErrorExamples.value(), actualPath);
+            }
+
+            return operation;
+        };
+    }
+
+    private String extractActualPath(HandlerMethod handlerMethod) {
+        try {
+            RequestMappingHandlerMapping mapping = applicationContext.getBean(RequestMappingHandlerMapping.class);
+            Map<RequestMappingInfo, HandlerMethod> handlerMethods = mapping.getHandlerMethods();
+
+            for (Map.Entry<RequestMappingInfo, HandlerMethod> entry : handlerMethods.entrySet()) {
+                if (entry.getValue().equals(handlerMethod)) {
+                    RequestMappingInfo info = entry.getKey();
+
+                    var pathPatternsCondition = info.getPathPatternsCondition();
+                    if (pathPatternsCondition != null && !pathPatternsCondition.getPatterns().isEmpty()) {
+                        return pathPatternsCondition.getPatterns().iterator().next().getPatternString();
+                    }
+
+                    var patternsCondition = info.getPatternsCondition();
+                    if (patternsCondition != null && !patternsCondition.getPatterns().isEmpty()) {
+                        return patternsCondition.getPatterns().iterator().next();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // 경로 추출 실패시 기본값 사용
+        }
+
+        return "/api/example";
+    }
+
+    private void generateErrorCodeResponseExample(Operation operation, ErrorCode[] errorCodes, String actualPath) {
+        ApiResponses responses = operation.getResponses();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders = Arrays.stream(errorCodes)
+                .map(errorCode -> ExampleHolder.builder()
+                        .example(createErrorExample(errorCode, actualPath))
+                        .name(errorCode.name())
+                        .httpStatus(errorCode.getStatus().value())
+                        .build())
+                .collect(Collectors.groupingBy(ExampleHolder::getHttpStatus));
+
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private Example createErrorExample(ErrorCode errorCode, String actualPath) {
+        Map<String, Object> errorResponse = new LinkedHashMap<>();
+        errorResponse.put("timestamp", "2025-06-30T12:00:00.000000");
+        errorResponse.put("status", errorCode.getStatus().value());
+        errorResponse.put("code", errorCode.name());
+        errorResponse.put("message", errorCode.getMessage());
+        errorResponse.put("path", actualPath);
+
+        Example example = new Example();
+        example.description(errorCode.getMessage());
+        example.setValue(errorResponse);
+
+        return example;
+    }
+
+    private void addExamplesToResponses(ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach((httpStatus, exampleHolders) -> {
+            String statusKey = httpStatus.toString();
+            ApiResponse apiResponse = responses.get(statusKey);
+
+            if (apiResponse == null) {
+                apiResponse = new ApiResponse();
+                apiResponse.setDescription("에러 응답");
+                apiResponse.setContent(new Content());
+            }
+
+            Content content = apiResponse.getContent();
+            MediaType mediaType = content.get("application/json");
+
+            if (mediaType == null) {
+                mediaType = new MediaType();
+                content.addMediaType("application/json", mediaType);
+            }
+
+            Map<String, Example> examples = mediaType.getExamples();
+            if (examples == null) {
+                examples = new HashMap<>();
+                mediaType.setExamples(examples);
+            }
+
+            for (ExampleHolder exampleHolder : exampleHolders) {
+                examples.put(exampleHolder.getName(), exampleHolder.getExample());
+            }
+
+            responses.addApiResponse(statusKey, apiResponse);
+        });
+    }
+
+    @Getter
+    @Builder
+    private static class ExampleHolder {
+        private final Example example;
+        private final String name;
+        private final int httpStatus;
+    }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface ApiErrorExamples {
+        ErrorCode[] value();
     }
 }

--- a/src/main/java/com/lol/highlight/global/config/WebConfig.java
+++ b/src/main/java/com/lol/highlight/global/config/WebConfig.java
@@ -1,6 +1,8 @@
 package com.lol.highlight.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -15,5 +17,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/com/lol/highlight/global/exception/ErrorCode.java
+++ b/src/main/java/com/lol/highlight/global/exception/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C004", "Entity not found"),
     INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C005", "Invalid type value"),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "C006", "Access is denied"),
+    REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "C007", "Required field is missing"),
+    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "C008", "External API error"),
+    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "C009", "Authentication is required"),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "User not found"),

--- a/src/main/java/com/lol/highlight/global/external/riot/client/RiotApiClient.java
+++ b/src/main/java/com/lol/highlight/global/external/riot/client/RiotApiClient.java
@@ -1,0 +1,120 @@
+package com.lol.highlight.global.external.riot.client;
+
+import com.lol.highlight.global.external.riot.dto.RiotLeagueDto;
+import com.lol.highlight.global.external.riot.dto.RiotMatchDto;
+import com.lol.highlight.global.external.riot.dto.RiotSummonerDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RiotApiClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${riot.api.key}")
+    private String apiKey;
+
+    @Value("${riot.api.base-url:https://kr.api.riotgames.com}")
+    private String baseUrl;
+
+    @Value("${riot.api.asia-url:https://asia.api.riotgames.com}")
+    private String asiaUrl;
+
+    public RiotSummonerDto getSummonerByRiotId(String gameName, String tagLine) {
+        String url = String.format("%s/riot/account/v1/accounts/by-riot-id/%s/%s",
+                asiaUrl, gameName, tagLine);
+
+        log.info("Fetching summoner by Riot ID: {}#{}", gameName, tagLine);
+
+        ResponseEntity<RiotSummonerDto> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                createHttpEntity(),
+                RiotSummonerDto.class
+        );
+
+        return response.getBody();
+    }
+
+    public RiotSummonerDto getSummonerByPuuid(String puuid) {
+        String url = String.format("%s/lol/summoner/v4/summoners/by-puuid/%s",
+                baseUrl, puuid);
+
+        log.info("Fetching summoner by PUUID: {}", puuid);
+
+        ResponseEntity<RiotSummonerDto> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                createHttpEntity(),
+                RiotSummonerDto.class
+        );
+
+        return response.getBody();
+    }
+
+    public List<RiotLeagueDto> getLeagueBySummonerId(String summonerId) {
+        String url = String.format("%s/lol/league/v4/entries/by-summoner/%s",
+                baseUrl, summonerId);
+
+        log.info("Fetching league by summoner ID: {}", summonerId);
+
+        ResponseEntity<List<RiotLeagueDto>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                createHttpEntity(),
+                new ParameterizedTypeReference<List<RiotLeagueDto>>() {}
+        );
+
+        return response.getBody();
+    }
+
+    public List<String> getMatchIdsByPuuid(String puuid, int count) {
+        String url = String.format("%s/lol/match/v5/matches/by-puuid/%s/ids?start=0&count=%d",
+                asiaUrl, puuid, count);
+
+        log.info("Fetching match IDs by PUUID: {}, count: {}", puuid, count);
+
+        ResponseEntity<List<String>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                createHttpEntity(),
+                new ParameterizedTypeReference<List<String>>() {}
+        );
+
+        return response.getBody();
+    }
+
+    public RiotMatchDto getMatchById(String matchId) {
+        String url = String.format("%s/lol/match/v5/matches/%s",
+                asiaUrl, matchId);
+
+        log.info("Fetching match by ID: {}", matchId);
+
+        ResponseEntity<RiotMatchDto> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                createHttpEntity(),
+                RiotMatchDto.class
+        );
+
+        return response.getBody();
+    }
+
+    private HttpEntity<Void> createHttpEntity() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Riot-Token", apiKey);
+        return new HttpEntity<>(headers);
+    }
+}

--- a/src/main/java/com/lol/highlight/global/external/riot/dto/RiotLeagueDto.java
+++ b/src/main/java/com/lol/highlight/global/external/riot/dto/RiotLeagueDto.java
@@ -1,0 +1,17 @@
+package com.lol.highlight.global.external.riot.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RiotLeagueDto {
+
+    private String queueType;
+    private String tier;
+    private String rank;
+    private String summonerId;
+    private Integer leaguePoints;
+    private Integer wins;
+    private Integer losses;
+}

--- a/src/main/java/com/lol/highlight/global/external/riot/dto/RiotMatchDto.java
+++ b/src/main/java/com/lol/highlight/global/external/riot/dto/RiotMatchDto.java
@@ -1,0 +1,91 @@
+package com.lol.highlight.global.external.riot.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RiotMatchDto {
+
+    private Metadata metadata;
+    private Info info;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Metadata {
+        private String matchId;
+        private List<String> participants;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Info {
+        private Long gameCreation;
+        private Long gameDuration;
+        private List<Participant> participants;
+        private List<Team> teams;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Participant {
+        private String puuid;
+        private String summonerName;
+        private String riotIdGameName;
+        private String riotIdTagline;
+        private String championName;
+        private Integer championId;
+        private Integer kills;
+        private Integer deaths;
+        private Integer assists;
+        private Integer totalDamageDealtToChampions;
+        private Integer totalDamageTaken;
+        private Integer goldEarned;
+        private Integer totalMinionsKilled;
+        private Integer neutralMinionsKilled;
+        private Integer visionScore;
+        private Integer item0;
+        private Integer item1;
+        private Integer item2;
+        private Integer item3;
+        private Integer item4;
+        private Integer item5;
+        private Integer item6;
+        private Boolean win;
+        private Integer teamId;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Team {
+        private Integer teamId;
+        private Boolean win;
+        private Objectives objectives;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Objectives {
+        private Objective baron;
+        private Objective dragon;
+        private Objective tower;
+        private Objective inhibitor;
+        private Objective riftHerald;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Objective {
+        private Integer kills;
+    }
+}

--- a/src/main/java/com/lol/highlight/global/external/riot/dto/RiotSummonerDto.java
+++ b/src/main/java/com/lol/highlight/global/external/riot/dto/RiotSummonerDto.java
@@ -1,0 +1,24 @@
+package com.lol.highlight.global.external.riot.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RiotSummonerDto {
+
+    private String id;
+    private String accountId;
+    private String puuid;
+    private String name;
+
+    @JsonProperty("profileIconId")
+    private Integer profileIconId;
+
+    @JsonProperty("revisionDate")
+    private Long revisionDate;
+
+    @JsonProperty("summonerLevel")
+    private Long summonerLevel;
+}

--- a/src/main/java/com/lol/highlight/global/service/S3Service.java
+++ b/src/main/java/com/lol/highlight/global/service/S3Service.java
@@ -1,0 +1,208 @@
+package com.lol.highlight.global.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lol.highlight.domain.match.dto.MatchDetailResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+    private final ObjectMapper objectMapper;
+
+    @Value("${aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${aws.s3.match-data-prefix:match-data}")
+    private String matchDataPrefix;
+
+    public String uploadMatchData(String matchId, MatchDetailResponse matchDetail) {
+        try {
+            String key = String.format("%s/%s.csv", matchDataPrefix, matchId);
+            String csvData = convertToCsv(matchDetail);
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType("text/csv")
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromString(csvData, StandardCharsets.UTF_8));
+
+            String url = String.format("https://%s.s3.amazonaws.com/%s", bucketName, key);
+            log.info("Successfully uploaded match data to S3: {}", url);
+
+            return url;
+
+        } catch (Exception e) {
+            log.error("Failed to upload match data to S3 for matchId: {}", matchId, e);
+            throw new RuntimeException("Failed to upload match data to S3", e);
+        }
+    }
+
+    public MatchDetailResponse downloadMatchData(String detailDataUrl) {
+        try {
+            String key = extractKeyFromUrl(detailDataUrl);
+
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            byte[] data = s3Client.getObject(getObjectRequest).readAllBytes();
+            String csvData = new String(data, StandardCharsets.UTF_8);
+
+            MatchDetailResponse matchDetail = parseCsv(csvData);
+            log.info("Successfully downloaded match data from S3: {}", detailDataUrl);
+
+            return matchDetail;
+
+        } catch (IOException e) {
+            log.error("Failed to download match data from S3: {}", detailDataUrl, e);
+            throw new RuntimeException("Failed to download match data from S3", e);
+        }
+    }
+
+    private String extractKeyFromUrl(String url) {
+        int bucketEndIndex = url.indexOf(".s3.amazonaws.com/");
+        if (bucketEndIndex == -1) {
+            throw new IllegalArgumentException("Invalid S3 URL format: " + url);
+        }
+        return url.substring(bucketEndIndex + ".s3.amazonaws.com/".length());
+    }
+
+    private String convertToCsv(MatchDetailResponse matchDetail) {
+        StringBuilder csv = new StringBuilder();
+
+        csv.append("playerName,championName,kills,deaths,assists,totalDamageDealt,visionScore,cs,finalItems,goldEarned\n");
+
+        for (MatchDetailResponse.PlayerDetail player : matchDetail.getPlayers()) {
+            csv.append(escapeCSV(player.getPlayerName())).append(",");
+            csv.append(escapeCSV(player.getChampionName())).append(",");
+            csv.append(player.getKills()).append(",");
+            csv.append(player.getDeaths()).append(",");
+            csv.append(player.getAssists()).append(",");
+            csv.append(player.getTotalDamageDealt()).append(",");
+            csv.append(player.getVisionScore()).append(",");
+            csv.append(player.getCs()).append(",");
+            csv.append(escapeCSV(player.getFinalItems().toString())).append(",");
+            csv.append(player.getGoldEarned()).append("\n");
+        }
+
+        csv.append("\nTEAMS\n");
+        csv.append("teamId,win,totalObjectives,totalKills\n");
+
+        for (MatchDetailResponse.TeamDetail team : matchDetail.getTeams()) {
+            csv.append(team.getTeamId()).append(",");
+            csv.append(team.getWin()).append(",");
+            csv.append(team.getTotalObjectives()).append(",");
+            csv.append(team.getTotalKills()).append("\n");
+        }
+
+        return csv.toString();
+    }
+
+    private MatchDetailResponse parseCsv(String csvData) throws IOException {
+        BufferedReader reader = new BufferedReader(new StringReader(csvData));
+        List<MatchDetailResponse.PlayerDetail> players = new ArrayList<>();
+        List<MatchDetailResponse.TeamDetail> teams = new ArrayList<>();
+
+        String line;
+        boolean isTeamSection = false;
+        boolean isHeader = true;
+
+        while ((line = reader.readLine()) != null) {
+            if (line.trim().isEmpty()) {
+                continue;
+            }
+
+            if (line.equals("TEAMS")) {
+                isTeamSection = true;
+                isHeader = true;
+                continue;
+            }
+
+            if (isHeader) {
+                isHeader = false;
+                continue;
+            }
+
+            String[] values = line.split(",");
+
+            if (!isTeamSection) {
+                MatchDetailResponse.PlayerDetail player = MatchDetailResponse.PlayerDetail.builder()
+                        .playerName(values[0])
+                        .championName(values[1])
+                        .kills(Integer.parseInt(values[2]))
+                        .deaths(Integer.parseInt(values[3]))
+                        .assists(Integer.parseInt(values[4]))
+                        .totalDamageDealt(Integer.parseInt(values[5]))
+                        .visionScore(Integer.parseInt(values[6]))
+                        .cs(Integer.parseInt(values[7]))
+                        .finalItems(parseIntegerList(values[8]))
+                        .goldEarned(Integer.parseInt(values[9]))
+                        .itemBuild(new ArrayList<>())
+                        .skillBuild(new ArrayList<>())
+                        .build();
+                players.add(player);
+            } else {
+                MatchDetailResponse.TeamDetail team = MatchDetailResponse.TeamDetail.builder()
+                        .teamId(Integer.parseInt(values[0]))
+                        .win(Boolean.parseBoolean(values[1]))
+                        .totalObjectives(Integer.parseInt(values[2]))
+                        .totalKills(Integer.parseInt(values[3]))
+                        .build();
+                teams.add(team);
+            }
+        }
+
+        return MatchDetailResponse.builder()
+                .matchId("")
+                .players(players)
+                .teams(teams)
+                .build();
+    }
+
+    private String escapeCSV(String value) {
+        if (value == null) {
+            return "";
+        }
+        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    private List<Integer> parseIntegerList(String value) {
+        value = value.replace("[", "").replace("]", "").trim();
+        if (value.isEmpty()) {
+            return new ArrayList<>();
+        }
+        String[] parts = value.split(",\\s*");
+        List<Integer> result = new ArrayList<>();
+        for (String part : parts) {
+            try {
+                result.add(Integer.parseInt(part.trim()));
+            } catch (NumberFormatException e) {
+                result.add(0);
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Summary

  - 사용자 전적 조회 및 갱신 기능 구현
  - Riot API 연동 및 S3 기반 매치 상세 데이터 저장
  - 30분 캐시 및 3분 갱신 제한 로직 구현

  Changes

  엔티티 수정

  - User: 소환사 정보 필드 추가 (tier, rank, LP, wins, losses, winRate 등)
  - User: lastActivityAt, lastMatchRefreshAt 필드 추가 (캐시 및 갱신 제한)
  - Match: detailDataUrl 필드 추가 (S3 URL 저장)

  새로운 기능

  - MatchHistoryController: 전적 조회/갱신 API 엔드포인트
    - GET /api/matches/user/{userId}: 전적 목록 조회
    - GET /api/matches/{matchId}/detail: 매치 상세 조회
    - POST /api/matches/user/{userId}/refresh: 전적 갱신
  - MatchHistoryService: 전적 조회/갱신 비즈니스 로직
    - 30분 캐시 로직 (마지막 활동 시간 기반)
    - 3분 갱신 제한 (Rate limiting)
    - Riot API 호출 및 데이터 변환
    - 소환사 정보 동시 갱신

  인프라

  - S3Config, S3Service: AWS S3 연동 (CSV 형태 저장)
  - RiotApiClient: Riot API 호출 클라이언트
    - 소환사 정보 조회 (summoner-v4, league-v4)
    - 매치 데이터 조회 (match-v5)

  DTO

  - MatchDetailResponse: 매치 상세 정보 (10명 플레이어, 2개 팀)
  - RiotSummonerDto, RiotLeagueDto, RiotMatchDto: Riot API 응답 매핑

  설정 및 개선

  - build.gradle: AWS S3 SDK 의존성 추가
  - WebConfig: RestTemplate Bean 추가
  - SwaggerConfig: ApiErrorExamples 애노테이션 및 OperationCustomizer 추가
  - ErrorCode: AUTHENTICATION_REQUIRED, EXTERNAL_API_ERROR, REQUIRED_FIELD_MISSING 추가

  Technical Details

  데이터 저장 전략

  - DB: 매치 요약 정보 (KDA, 승/패, 챔피언 등)
  - S3: 매치 상세 데이터 CSV 형태 저장 (10명 플레이어 상세 정보)

  캐시 전략

  - 마지막 활동 시간 기반 30분 캐시
  - DB에 전적이 없거나 30분 경과 시 갱신 권장
  - 전적 갱신은 3분에 한번만 가능 (Rate limiting)

  API 통합

  - Riot API v5 사용
  - 소환사 정보 + 전적 동시 갱신
  - 비동기 처리 및 에러 핸들링

  Test Plan

  - 전적 조회 API 테스트
  - 전적 갱신 API 테스트 (3분 제한 확인)
  - S3 CSV 업로드/다운로드 테스트
  - Riot API 연동 테스트
  - 30분 캐시 로직 테스트
  - 에러 처리 및 예외 상황 테스트

  Configuration Required

  # AWS S3
  aws.s3.access-key=your-access-key
  aws.s3.secret-key=your-secret-key
  aws.s3.region=ap-northeast-2
  aws.s3.bucket=your-bucket-name
  aws.s3.match-data-prefix=match-data

  # Riot API
  riot.api.key=your-riot-api-key
  riot.api.base-url=https://kr.api.riotgames.com
  riot.api.asia-url=https://asia.api.riotgames.com
